### PR TITLE
Add a basic Recipes endpoint to the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby '2.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgres as the database for Active Record
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    pg (1.2.3)
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
@@ -178,7 +179,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -216,6 +216,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.11)
   rails (~> 5.2.3)
   react-rails
@@ -223,7 +224,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,0 +1,49 @@
+class Api::V1::RecipesController < ApplicationController
+  def index
+    recipe = Recipe.all.order(created_at: :desc)
+    render json: recipe
+  end
+
+  def create
+    recipe = Recipe.create!(recipe_params)
+    if recipe
+      render json: recipe
+    else
+      render json: recipe.errors
+    end
+  end
+
+  def show
+    if recipe
+      render json: recipe
+    else
+      render json: recipe.errors
+    end
+  end
+
+  def destroy
+    recipe&.destroy
+    render json: { message: 'Recipe deleted.' }
+  end
+
+  private
+
+  def recipe_params
+    params.permit(
+      :name, 
+      :difficulty,
+      :food_type,
+      :serving_size,
+      :duration,
+      :ingredients, 
+      :instructions,
+      :notes,
+      :tags,
+      :image,
+    )
+  end
+
+  def recipe
+    @recipe ||= Recipe.find(params[:id])
+  end
+end

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RecipesController < ApplicationController
   def index
-    recipe = Recipe.all.order(created_at: :desc)
+    recipe = Recipe.all.order(created_at: :asc)
     render json: recipe
   end
 

--- a/app/javascript/components/Recipes.js
+++ b/app/javascript/components/Recipes.js
@@ -1,13 +1,67 @@
 import React, { Component } from 'react'
-import { Button } from 'antd';
+import { Table } from 'antd';
 
 class Recipes extends Component {
+  constructor(props) {
+    super(props);
+     // The state of a component can update. Whenever it updates, it re-renders with the new information!
+    this.state = {
+      recipes: []
+    }
+  }
+
+  // This function gets called as soon as the component gets loaded 
+  // So, this is where we're gonna fetch information from the backend
+  // In this case, we're grabbing all of the recipes in the database and storing it in 'recipes'
+  componentDidMount() {
+    const url = "/api/v1/recipes/index";
+    fetch(url)
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        }
+        throw new Error("Network response was not okay");
+      })
+      // If the response from the backend is okay, then we update the state of this component to include 
+      // the recipes we just got
+      .then(response => this.setState({ recipes: response}))
+      .catch(() => this.props.history.push("/"));
+  }
+
   render() {
+    const { recipes } = this.state;
+
+    // This labels the columns, and determines what values will be populated in each column
+    // dataIndex is the key inside recipes that corresponds to the name, i.e. recipes.name
+    // The different fields for a Recipe can be found in app/controllers/api/v1/recipes_controller.rb#recipe_params
+    const columns = [
+      {
+        title: 'Name', // This is the label
+        dataIndex: 'name', 
+        key: 'name',
+        render: text => <a>{text}</a>,
+      },
+      {
+        title: 'Type of Food',
+        dataIndex: 'food_type',
+        key: 'food_type',
+      },
+      {
+        title: 'Duration',
+        dataIndex: 'duration',
+        key: 'duration',
+      },
+      {
+        title: 'Difficulty',
+        dataIndex: 'difficulty',
+        key: 'difficulty',
+      },
+    ]
+
+    // Should make the table entries clickable, and when we click it
+    // sends you to the individualized recipe page.
     return(
-      <div>
-        <Button type="primary">Heyo I'm a button</Button>
-        Heyo welcome to the recipes page
-      </div>
+      <Table columns={columns} dataSource={recipes}/>
     )
   }
 }

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,0 +1,2 @@
+class Recipe < ApplicationRecord
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,7 @@ require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
+ActiveSupport::Deprecation.behavior = :silence
 Bundler.require(*Rails.groups)
 
 module HoneyLemonRecipes

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,54 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# PostgreSQL. Versions 8.2 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: pt2pham
+  password: <%= ENV['HONEY_LEMON_RECIPES_DB_PASSWORD']>
   timeout: 5000
+  
 
 development:
   <<: *default
-  database: db/development.sqlite3
-
+  database: honey-lemon-recipes_development
+ 
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+ 
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+ 
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+ 
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+ 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  database: honey-lemon-recipes_test
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,15 @@
 Rails.application.routes.draw do
-  root 'pages#index'
-
   ### API Routes
-  # namespace :api do
-  #   namespace :v1 do
-  #     resources :recipes, param: :slug
-  #   end
-  # end
+  namespace :api do
+    namespace :v1 do
+      get 'recipes/index'
+      post 'recipes/create'
+      get 'show/:id', to: 'recipes#show'
+      delete '/destroy/:id', to: 'recipes#destroy'
+    end
+  end
+
+  root 'pages#index'
 
   ### Frontend React Routes
   match '*path', to: 'pages#index', via: :all

--- a/db/migrate/20200703172339_create_recipes.rb
+++ b/db/migrate/20200703172339_create_recipes.rb
@@ -6,7 +6,7 @@ class CreateRecipes < ActiveRecord::Migration[5.2]
       t.string :food_type, null: false
       t.string :serving_size, null: false
       t.integer :duration, null: false
-      t.text :ingredients, null: false
+      t.text :ingredients, null: false # I might make this be a relation to an Ingredients model 
       t.text :instructions, null: false
       t.text :notes
       t.text :tags

--- a/db/migrate/20200703172339_create_recipes.rb
+++ b/db/migrate/20200703172339_create_recipes.rb
@@ -1,0 +1,18 @@
+class CreateRecipes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :recipes do |t|
+      t.string :name, null: false
+      t.float :difficulty, null: false
+      t.string :food_type, null: false
+      t.string :serving_size, null: false
+      t.integer :duration, null: false
+      t.text :ingredients, null: false
+      t.text :instructions, null: false
+      t.text :notes
+      t.text :tags
+      t.string :image, default: 'https://www.ilac.com/wp-content/uploads/2019/06/placeholder-600x400.png'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,33 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_07_03_172339) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "recipes", force: :cascade do |t|
+    t.string "name", null: false
+    t.float "difficulty", null: false
+    t.string "food_type", null: false
+    t.string "serving_size", null: false
+    t.integer "duration", null: false
+    t.text "ingredients", null: false
+    t.text "instructions", null: false
+    t.text "notes"
+    t.text "tags"
+    t.string "image", default: "https://www.ilac.com/wp-content/uploads/2019/06/placeholder-600x400.png"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,17 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+9.times do |i|
+  Recipe.create(
+    name: "Lemon #{i + 1}",
+    difficulty: i,
+    food_type: "Yemon",
+    serving_size: i,
+    duration: 10,
+    ingredients: "1 tbsp lemon juice;#{i + 1} tbsp honey",
+    instructions: "Mix it real nice",
+    notes: "This is one of the best recipes in the world! It's my life story.",
+    tags: "cool;hip;citrus;summer;sweet",
+  )
+end

--- a/test/controllers/api/v1/recipes_controller_test.rb
+++ b/test/controllers/api/v1/recipes_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Api::V1::RecipesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_v1_recipes_index_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get api_v1_recipes_create_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get api_v1_recipes_show_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get api_v1_recipes_destroy_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -1,0 +1,25 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  difficulty: 1.5
+  food_type: MyString
+  serving_size: MyString
+  duration: 1
+  ingredients: MyText
+  instructions: MyText
+  notes: MyText
+  tags: MyText
+  image: MyString
+
+two:
+  name: MyString
+  difficulty: 1.5
+  food_type: MyString
+  serving_size: MyString
+  duration: 1
+  ingredients: MyText
+  instructions: MyText
+  notes: MyText
+  tags: MyText
+  image: MyString

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RecipeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This adds some basic functionality for interacting with Recipes. So far, we'll be able to view all recipes, select a single one, delete one, and create one. 

### Backend things

The features of a recipe are as follows:
![image](https://user-images.githubusercontent.com/12602560/86501159-56458f80-bd64-11ea-8f02-0f44927a6c49.png)

This should cover most of the functionality on the backend. Other things will probably need to be added but this is enough to work with for now!

### Frontend things

I'm using the Table component from Ant Design to display all the information for the All Recipes page. We can change this up (and probably will), but I just wrote it to test connecting to the backend properly. It's also an example of how to access data from the backend! :D

![image](https://user-images.githubusercontent.com/12602560/86501069-ac660300-bd63-11ea-9526-f3ff8753c81e.png)
